### PR TITLE
feat: add qr_string to Landmark

### DIFF
--- a/backend/prisma/migrations/20260401145307_add_qr_string_to_landmark/migration.sql
+++ b/backend/prisma/migrations/20260401145307_add_qr_string_to_landmark/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[qr_string]` on the table `landmarks` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `qr_string` to the `landmarks` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "landmarks" ADD COLUMN     "qr_string" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "landmarks_qr_string_key" ON "landmarks"("qr_string");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Landmark {
   name        String             @unique @db.VarChar(100)
   description String?
   fun_fact    String?
+  qr_string   String             @unique
   visitors    LandmarksVisited[]
 
   @@map("landmarks")


### PR DESCRIPTION
Added missing missing qr_string attribute in Landmark model. This is necessary for checking if the QR code scanned by the user matches with those in the database.