### PR TITLE
feat: add QuestionResponses model and update relations

### DIFF
--- a/backend/prisma/migrations/20260401145307_add_qr_string_to_landmark/migration.sql
+++ b/backend/prisma/migrations/20260401145307_add_qr_string_to_landmark/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[qr_string]` on the table `landmarks` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `qr_string` to the `landmarks` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "landmarks" ADD COLUMN     "qr_string" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "landmarks_qr_string_key" ON "landmarks"("qr_string");

--- a/backend/prisma/migrations/20260401182050_add_password_to_student/migration.sql
+++ b/backend/prisma/migrations/20260401182050_add_password_to_student/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `password` to the `students` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "students" ADD COLUMN     "password" VARCHAR(255) NOT NULL;

--- a/backend/prisma/migrations/20260404133434_add_program_and_specialization_to_student/migration.sql
+++ b/backend/prisma/migrations/20260404133434_add_program_and_specialization_to_student/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `program` to the `students` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `year_level` to the `students` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "students" ADD COLUMN     "program" VARCHAR(50) NOT NULL,
+ADD COLUMN     "specialization" VARCHAR(50),
+ADD COLUMN     "year_level" INTEGER NOT NULL;

--- a/backend/prisma/migrations/20260404190037_add_question_responses_and_update_relations/migration.sql
+++ b/backend/prisma/migrations/20260404190037_add_question_responses_and_update_relations/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable
+ALTER TABLE "quiz_submissions" ALTER COLUMN "quiz_id" DROP DEFAULT;
+DROP SEQUENCE "quiz_submissions_quiz_id_seq";
+
+-- CreateTable
+CREATE TABLE "question_submissions" (
+    "student_number" VARCHAR(20) NOT NULL,
+    "quiz_id" INTEGER NOT NULL,
+    "question_id" INTEGER NOT NULL,
+    "selected_idx" INTEGER NOT NULL,
+
+    CONSTRAINT "question_submissions_pkey" PRIMARY KEY ("student_number","quiz_id","question_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "question_submissions" ADD CONSTRAINT "question_submissions_student_number_fkey" FOREIGN KEY ("student_number") REFERENCES "students"("student_number") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "question_submissions" ADD CONSTRAINT "question_submissions_question_id_fkey" FOREIGN KEY ("question_id") REFERENCES "questions"("question_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "question_submissions" ADD CONSTRAINT "question_submissions_student_number_quiz_id_fkey" FOREIGN KEY ("student_number", "quiz_id") REFERENCES "quiz_submissions"("student_number", "quiz_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,6 +13,7 @@ model Student {
   middle_name         String?              @db.VarChar(50)
   last_name           String               @db.VarChar(50)
   email               String               @unique @db.VarChar(50)
+  password            String               @db.VarChar(255)
   created_at          DateTime             @default(now())
   achievements_earned AchievementsEarned[]
   landmarks_visited   LandmarksVisited[]

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,6 +12,9 @@ model Student {
   first_name          String               @db.VarChar(50)
   middle_name         String?              @db.VarChar(50)
   last_name           String               @db.VarChar(50)
+  program             String               @db.VarChar(50)
+  specialization      String?              @db.VarChar(50)
+  year_level          Int                  @db.Integer
   email               String               @unique @db.VarChar(50)
   password            String               @db.VarChar(255)
   created_at          DateTime             @default(now())

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,6 +22,7 @@ model Student {
   landmarks_visited   LandmarksVisited[]
   progress            Progress?
   quiz_submissions    QuizSubmission[]
+  question_responses  QuestionResponses[]
 
   @@map("students")
 }
@@ -55,6 +56,7 @@ model Question {
   correct_idx   Int
   item_points   Int    @default(10)
   quiz          Quiz   @relation(fields: [quiz_id], references: [quiz_id])
+  responses     QuestionResponses[]
 
   @@map("questions")
 }
@@ -80,15 +82,29 @@ model LandmarksVisited {
 }
 
 model QuizSubmission {
-  student_number String   @db.VarChar(20)
-  quiz_id        Int      @default(autoincrement())
-  score          Int
-  completed_at   DateTime @default(now())
-  quiz           Quiz     @relation(fields: [quiz_id], references: [quiz_id])
-  student        Student  @relation(fields: [student_number], references: [student_number])
+  student_number     String              @db.VarChar(20)
+  quiz_id            Int
+  score              Int
+  completed_at       DateTime            @default(now())
+  quiz               Quiz                @relation(fields: [quiz_id], references: [quiz_id])
+  student            Student             @relation(fields: [student_number], references: [student_number])
+  question_responses QuestionResponses[]
 
   @@id([student_number, quiz_id])
   @@map("quiz_submissions")
+}
+
+model QuestionResponses {
+  student_number  String         @db.VarChar(20)
+  quiz_id         Int
+  question_id     Int
+  selected_idx    Int
+  student         Student        @relation(fields: [student_number], references: [student_number])
+  question        Question       @relation(fields: [question_id], references: [question_id])
+  quiz_submission QuizSubmission @relation(fields: [student_number, quiz_id], references: [student_number, quiz_id])
+
+  @@id([student_number, quiz_id, question_id])
+  @@map("question_submissions")
 }
 
 model Progress {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Landmark {
   name        String             @unique @db.VarChar(100)
   description String?
   fun_fact    String?
+  qr_string   String             @unique
   visitors    LandmarksVisited[]
 
   @@map("landmarks")

--- a/backend/src/routes/quizzes.ts
+++ b/backend/src/routes/quizzes.ts
@@ -1,0 +1,130 @@
+import express, { type Request, type Response } from "express";
+import { prisma } from "../lib/prisma";
+import { authenticateToken } from "../middleware/auth.middleware";
+import { number } from "zod";
+
+const router = express.Router();
+
+router.use(authenticateToken);
+
+router.get("/", async (req: Request, res: Response) => {
+  try {
+    const quizzes = await prisma.quiz.findMany({
+      include: { questions: true }
+    });
+    res.json(quizzes);
+  } catch (error) {
+    res.json({
+      error: "Failed to fetch quizzes"
+    })
+  }
+})
+
+router.get("/:id", async (req: Request, res: Response) => {
+  const studentNum = (req as any).user.studentNum;
+  const quizId = parseInt(req.params.id as string);
+
+  try {
+      const [quiz, studentProgress] = await Promise.all([
+        prisma.quiz.findUnique({
+          where: { quiz_id: quizId }
+        }),
+
+        prisma.progress.findUnique({
+          where: { student_number: studentNum },
+          select: { total_xp: true }
+        })
+    ]);
+
+    if (!quiz) {
+      return res.status(404).json({
+        error: "Quiz not found"
+      })
+    }
+
+    if ((studentProgress?.total_xp ?? 0) < quiz?.required_xp) {
+      res.status(403).json({
+        error: "Quiz is locked. You need more XP to unlock it."
+      })
+    }
+
+    const questions = await prisma.question.findMany({
+      where: { quiz_id: quizId }
+    })
+
+    res.json({
+      ...quiz,
+      questions
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: "Internal Server Error"
+    })
+  }
+})
+
+router.post("/:id/submit", (req: Request, res: Response) => {
+  const studentNum = (req as any).user.studentNum;
+  const quizId = parseInt(req.params.id as string);
+
+  const { answers } = req.body;
+
+  try {
+    const isAnswered = await prisma.quizSubmission.findUnique({
+      where: {
+        student_number_quiz_id: {
+          student_number: studentNum,
+          quiz_id: quizId
+        }
+      }
+    });
+
+    if (isAnswered) {
+      return res.status(409).json({
+        error: "Quiz is already answered"
+      });
+    }
+    
+    const questions = await prisma.question.findMany({
+      where: { quiz_id: quizId },
+      select: {
+        question_text: true,
+        correct_idx: true,
+        item_points: true
+      }
+    });
+
+    let totalScore = 0;
+
+    const result = questions.map((question, index) => {
+      const isCorrect = question.correct_idx === answers[index];
+      if (isCorrect) totalScore += question.item_points;
+
+      return {
+        question_text: question.question_text,
+        
+      }
+    })
+
+    for (let i=0; i<questions.length; i++) {
+      if (questions[i]?.correct_idx === answers[i]) {
+        score += questions[i]?.item_points ?? 0; 
+      }
+    }
+
+    await prisma.quizSubmission.create({
+      data: {
+        student_number: studentNum,
+        quiz_id: quizId,
+        score: score
+      }
+    })
+
+    return res.status(200).json({
+      message: "Quiz submitted successfully",
+      score: score,
+      questions: 
+    })
+  }
+
+})


### PR DESCRIPTION
# Overview

This PR updates the Prisma schema to support the quiz submission system. It establishes the necessary relational structures to enforce a single submission rule and allows for granular tracking of individual student responses.

# Key Changes:

* **`QuestionResponses` Model:** Introduced to store specific choices made by students for every question.

* **Relational Hardening:**
   * Established a direct relation between `Student` and `QuestionResponses` for faster analytics queries.
   * Linked `QuestionResponses` to both the parent `QuizSubmission` and the specific `Question`.

* **Migration:** Generated migration `20260404190037_add_question_responses_and_update_relations` to sync the PostgreSQL provider.