### PR TITLE
refactor: visit landmark endpoint now uses QR-based lookup

### DIFF
--- a/backend/src/controllers/landmarks.controller.ts
+++ b/backend/src/controllers/landmarks.controller.ts
@@ -30,10 +30,9 @@ async function getLandmark(req: Request, res: Response) {
 async function visitLandmark(req: Request, res: Response) {
   try {
     const studentNum = (req as any).user.studentNum;
-    const landmarkId = parseInt(req.params.id as string);
     const { qr_code_scanned } = req.body;
 
-    const newVisit = await landmarksService.processLandmarkVisit(studentNum, landmarkId, qr_code_scanned);
+    const newVisit = await landmarksService.processLandmarkVisit(studentNum, qr_code_scanned);
 
     return res.status(200).json(newVisit);
   } catch (error: any) {

--- a/backend/src/repositories/landmarks.repository.ts
+++ b/backend/src/repositories/landmarks.repository.ts
@@ -31,6 +31,12 @@ async function findLandmarkVisitedByStudent(studentNum: string, landmarkId: numb
   });
 }
 
+async function findLandmarkByQr(qrString: string) {
+  return prisma.landmark.findUnique({
+    where: { qr_string: qrString }
+  });
+}
+
 async function findLandmarksVisitedCount(studentNum: string) {
   return prisma.landmarksVisited.count({
     where: { student_number: studentNum }
@@ -69,6 +75,7 @@ export {
   findLandmarksVisitedByStudent,
   findLandmark,
   findLandmarkVisitedByStudent,
+  findLandmarkByQr,
   findLandmarksVisitedCount,
   createLandmarkVisit
 }

--- a/backend/src/routes/landmarks.route.ts
+++ b/backend/src/routes/landmarks.route.ts
@@ -14,6 +14,6 @@ router.get("/", landmarksController.getLandmarkChecklist);
 router.get("/:id", landmarksController.getLandmark);
 
 // VISIT LANDMARK ENDPOINT
-router.post("/:id/visit", landmarksController.visitLandmark);
+router.post("/visit", landmarksController.visitLandmark);
 
 export default router;

--- a/backend/src/services/landmarks.service.ts
+++ b/backend/src/services/landmarks.service.ts
@@ -55,11 +55,10 @@ async function fetchLandmark(studentNum: string, landmarkId: number) {
 
 async function processLandmarkVisit(
   studentNum: string,
-  landmarkId: number,
   qrCodeScanned: string
 ) {
-  const [ landmark, studentProgress ] = await Promise.all([
-    landmarksRepository.findLandmark(landmarkId),
+  const [landmark, studentProgress ] = await Promise.all([
+    landmarksRepository.findLandmarkByQr(qrCodeScanned),
     studentsRepository.findStudentProgress(studentNum)
   ]);
 
@@ -80,7 +79,7 @@ async function processLandmarkVisit(
 
   const { newVisit, updatedProgress } = await landmarksRepository.createLandmarkVisit(
     studentNum,
-    landmarkId,
+    landmark.landmark_id,
     xpReward,
     newLevel
   );

--- a/documentations/logs/week-04/2026-04-22-landmark-visit-refactor.md
+++ b/documentations/logs/week-04/2026-04-22-landmark-visit-refactor.md
@@ -1,0 +1,46 @@
+| Field | Details |
+| :--- | :--- |
+| **Date** | 2026-04-22 |
+| **Project** | EUventure |
+| **Topic** | Landmark Visit Refactor & QR-Based Lookup |
+| **Developer** | Tagle |
+| **Tags** | `Landmarks`, `Refactoring`, `API-Optimization` |
+
+# DEV LOG: WEEK 4 - DAY 5
+
+## Core Objective
+
+Refactor the landmark "visit" workflow to shift lookup logic from the frontend to the backend. The goal is to eliminate the need for the mobile app to fetch the entire landmark checklist just to map a scanned QR string to a landmark ID, thereby optimizing network performance and user experience.
+
+## 1. API & Route Optimization
+
+Streamlined the endpoint structure to simplify the request lifecycle for frontend developers.
+
+* **Route Flattening:** Renamed and simplified the endpoint from `/landmarks/:id/visit` to a direct `/landmarks/visit` POST route.
+
+* **Payload Simplification:** Transitioned from URL path parameters to a clean request body. The frontend now only needs to send the raw `qr_code_scanned` string.
+
+* **Network Efficiency:** Reduced the required sequence for a scan from two network requests (fetch-all + post-visit) to a single, atomic transaction.
+
+## 2. Service & Repository Enhancement
+
+Updated the business logic and data access layers to handle internal landmark resolution.
+
+* **QR-Based Lookup:** Introduced `findLandmarkByQr` in the `landmarks.repository.ts` to allow direct record retrieval using the persistent UUID string.
+
+* **Service Decoupling:** Refactored `processLandmarkVisit` in the service layer to remove the `landmarkId` dependency. The service now independently resolves the landmark record, validates the scan, and triggers gamification logic (XP and Level-ups).
+
+* **Validation Logic:** Maintained strict backend validation to ensure the scanned string matches the database record, preventing spoofed visits while allowing for a more flexible frontend implementation.
+
+## 3. Technical Summary of Changes
+
+### API Specification
+* **Old Endpoint:** `POST /landmarks/:id/visit`
+* **New Endpoint:** `POST /landmarks/visit`
+* **Payload:** `{ "qr_code_scanned": "string" }`
+
+### Modified Files
+* **Repository:** `backend/src/repositories/landmarks.repository.ts` (Added `findLandmarkByQr`)
+* **Service:** `backend/src/services/landmarks.service.ts` (Refactored `processLandmarkVisit`)
+* **Controller:** `backend/src/controllers/landmarks.controller.ts` (Updated `visitLandmark`)
+* **Routes:** `backend/src/routes/landmarks.route.ts` (Updated visit route)


### PR DESCRIPTION
# Overview

This PR refactors the landmark "visit" process to optimize frontend performance and simplify the scanning workflow. Previously, the frontend was required to provide a `landmarkId` in the URL (`/landmarks/:id/visit`), which forced client-side developers to fetch the entire checklist beforehand just to map a scanned QR string to a landmark ID.

By shifting the lookup logic to the backend, the frontend can now send the scanned QR string directly to a single endpoint. The backend resolves the correct landmark and processes the visit in one step, removing a significant bottleneck.

# Key Changes

## 1. Repository Layer (`landmarks.repository.ts`)

* **New Lookup Method:** Added `findLandmarkByQr` to allow the system to retrieve a full landmark record using only its unique `qr_string`.

## 2. Service Layer (`landmarks.service.ts`)

* **Signature Refactor:** Removed the `landmarkId` parameter from `processLandmarkVisit`.

* **Integrated Lookup:** The service now independently fetches the landmark using `findLandmarkByQr` and validates the scanned string before proceeding with gamification logic (XP rewards and level-ups).

## 3. Controller & Routing Layer

* **Route Simplification (`landmarks.route.ts`):** Renamed and flattened the endpoint from `/landmarks/:id/visit` to a clean POST request at `/landmarks/visit`.

* **Controller Cleanup (`landmarks.controller.ts`):** Updated `visitLandmark` to extract only the `qr_code_scanned` from the request body, completely removing the dependency on URL path parameters.

# Technical Note

* **Efficiency:** This change reduces the number of network requests required by the mobile app during a physical scan from two (fetch all + post visit) to one (post visit).

* **Security:** The backend continues to validate that the `qr_code_scanned` matches the database record to prevent spoofed visits.

# Summary of API Changes
* **Old Endpoint:** `POST /landmarks/:id/visit`
* **New Endpoint:** `POST /landmarks/visit`
* **Payload:** `{ "qr_code_scanned": "string" }`