### PR TITLE
refactor: lock unvisited landmarks and enhance discovery mechanic

### DIFF
--- a/backend/src/constants/error-maps.ts
+++ b/backend/src/constants/error-maps.ts
@@ -80,6 +80,12 @@ const ERRORS: ErrorDetails[] = [
     status: 500,
     message: "Failed to process scan" 
   },
+  {
+    type: "LANDMARK",
+    code: "LANDMARK_LOCKED",
+    status: 423,
+    message: "Scan landmark QR first" 
+  },
 
   // Quiz Errors
   {

--- a/backend/src/services/landmarks.service.ts
+++ b/backend/src/services/landmarks.service.ts
@@ -15,7 +15,7 @@ async function fetchLandmarkChecklist(studentNum: string) {
   // Final checklist to show on the frontend
   const landmarkList = allLandmarks.map((landmark) => {
     const isVisited = visitedIds.has(landmark.landmark_id);
-    const { fun_fact, qr_string, ...publicData } = landmark;
+    const { description, fun_fact, qr_string, ...publicData } = landmark;
 
     return {
       ...publicData,

--- a/backend/src/services/landmarks.service.ts
+++ b/backend/src/services/landmarks.service.ts
@@ -39,12 +39,7 @@ async function fetchLandmark(studentNum: string, landmarkId: number) {
   const { qr_string, ...publicData } = landmark;
 
   if (!visit) {
-    const { fun_fact, ...lockedData } = publicData;
-    
-    return {
-      ...lockedData,
-      is_unlocked: false,
-    };
+    throw new Error("Scan landmark QR first");
   }
 
   return {

--- a/documentations/logs/week-04/2026-04-25-lock-unvisited-landmarks.md
+++ b/documentations/logs/week-04/2026-04-25-lock-unvisited-landmarks.md
@@ -1,0 +1,39 @@
+| Field | Details |
+| :--- | :--- |
+| **Date** | 2026-04-25 |
+| **Project** | EUventure |
+| **Topic** | Landmark Discovery Mechanics and Content Access Control |
+| **Developer** | Tagle |
+| **Tags** | `Backend`, `Services`, `Logic-Refactoring`, `UX-Security`, `Error-Handling` |
+
+# DEV LOG: WEEK 4 - DAY 7
+
+## Core Objective
+
+Transition the landmark exploration from a static directory to a dynamic discovery-first experience. This update ensures that the educational value of the landmarks (descriptions and fun facts) remains hidden until physically unlocked, encouraging actual campus traversal.
+
+## 1. Discovery-Based Content Masking
+
+To maintain the scavenger hunt feel of EUventure, we have tightened the data visibility in the landmark checklist.
+
+* **Total Content Lockdown:** Refactored `fetchLandmarkChecklist` in the service layer. Previously, only the fun facts were hidden; now, the `description` is also excluded for unvisited landmarks.
+
+* **Encouraging Exploration:** Students can now only see the landmark's name and basic metadata. All rich educational content is stripped from the API response unless the `is_visited` flag is true, preventing spoiling the landmark's history before the student arrives.
+
+## 2. Secure Access Control
+
+We implemented a server-side gatekeeper to prevent unauthorized access to landmark data via direct URL manipulation or deep links.
+
+* **Restricted Direct Access:** Refactored `fetchLandmark` to validate a student's visit history. If a student tries to access a landmark's details (`/landmarks/:id`) without having scanned its unique QR code first, the system will now explicitly block the request.
+
+* **Backend Validation:** This ensures that discovery cannot be bypassed by simply guessing landmark IDs, keeping the gamification loop secure and meaningful.
+
+## 3. Error Handling & UI Feedback
+
+Standardized the communication between the backend and frontend for locked content.
+
+* **New `LANDMARK_LOCKED` Error:** Added a specific error definition to `error-maps.ts`.
+
+* **HTTP 423 Status Code:** Used the `423 Locked` status code to indicate that the resource is inaccessible due to a missing prerequisite (the scan).
+
+* **Semantic Messaging:** The error returns a clear "Scan landmark QR first" message. This allows the mobile frontend to gracefully handle the rejection and display a specific "Locked" UI state or a hint to the user.


### PR DESCRIPTION
# Overview

This PR refines the discovery mechanic of the campus exploration feature. To enhance the scavenger hunt experience, landmark details (both description and fun facts) are now strictly restricted until a student physically discovers and scans the landmark's QR code.

# Key Changes

## 1. Discovery-Based Content Masking

* **Checklist Refactor:** Updated `fetchLandmarkChecklist` in `landmarks.service.ts` to exclude both `description` and `fun_fact` fields for any landmark not yet visited by the student.

* **Mystery Mechanic:** This ensures that students only see names and basic info in their checklist, requiring a physical visit to unlock the full educational content and historical data.

## 2. Access Control & Error Handling

* **Restricted Access:** Refactored `fetchLandmark` to prevent direct API access to unvisited landmark details. If a student attempts to view a landmark they haven't scanned, the system now denies the request.

* **New Error Type:** Added `LANDMARK_LOCKED` to `error-maps.ts`. This provides a specific `423 Locked` status code and a "Scan landmark QR first" message, allowing the frontend to trigger specific "Locked" UI states or discovery hints.