### PR TITLE
refactor: change badge upload content type and fix question correct answer

### DIFF
--- a/backend/prisma/data/achievements.data.json
+++ b/backend/prisma/data/achievements.data.json
@@ -5,7 +5,7 @@
     "category": "EXPLORER",
     "tier": 1,
     "threshold": 1,
-    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/explorer-level-1.svg"
+    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/explorer-level-1.png"
   },
   {
     "title": "Wildcat Voyager",
@@ -13,7 +13,7 @@
     "category": "EXPLORER",
     "tier": 2,
     "threshold": 5,
-    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/explorer-level-2.svg"
+    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/explorer-level-2.png"
   },
   {
     "title": "Luzonian Trailblazer",
@@ -21,7 +21,7 @@
     "category": "EXPLORER",
     "tier": 3,
     "threshold": 10,
-    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/explorer-level-3.svg"
+    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/explorer-level-3.png"
   },
   {
     "title": "Envergan Aspirant",
@@ -29,7 +29,7 @@
     "category": "SCHOLAR",
     "tier": 1,
     "threshold": 50,
-    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/scholar-level-1.svg"
+    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/scholar-level-1.png"
   },
   {
     "title": "Wildcat Seeker",
@@ -37,7 +37,7 @@
     "category": "SCHOLAR",
     "tier": 2,
     "threshold": 100,
-    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/scholar-level-2.svg"
+    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/scholar-level-2.png"
   },
   {
     "title": "Luzonian Paragon",
@@ -45,6 +45,6 @@
     "category": "SCHOLAR",
     "tier": 3,
     "threshold": 150,
-    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/scholar-level-3.svg"
+    "img_path": "https://eufjupzszpgeadrnvigc.supabase.co/storage/v1/object/public/achievement-badges/scholar-level-3.png"
   }
 ]

--- a/backend/prisma/data/quizzes.data.json
+++ b/backend/prisma/data/quizzes.data.json
@@ -223,7 +223,7 @@
           "False"
         ],
         "item_points": 10,
-        "correct_idx": 1
+        "correct_idx": 0
       }
     ]
   },

--- a/backend/prisma/update-achievements-data.ts
+++ b/backend/prisma/update-achievements-data.ts
@@ -44,7 +44,7 @@ async function updateAchievementsData() {
 async function uploadBadge(baseName: string) {
   try {
     // Construct the full file name with extension
-    const fileName = `${baseName}.svg`;
+    const fileName = `${baseName}.png`;
 
     // Construct the file path to the badge file
     const filePath = path.join(badgesFolderPath, fileName);
@@ -62,7 +62,7 @@ async function uploadBadge(baseName: string) {
       .storage
       .from("achievement-badges")
       .upload(fileName, fileBuffer, {
-        contentType: "image/svg+xml",
+        contentType: "image/png",
         upsert: true,
       });
     


### PR DESCRIPTION
# Key Changes

* This PR refactors the `uploadBadge` function in `prisma/update-achievements-data.ts` to use `image/png` content type instead of `image/svg+xml` to resolve issues on rendering the achievement badge files on the frontend.

* After running `npm run seed`, the `img_path` values in `prisma/data/achievements.data.json` now link to the uploaded badge PNG files in Supabase.

* I also corrected the `correct_idx` of question 10 in quiz 2 `MSEUF Legacy and Milestones` from `1` to `0`.